### PR TITLE
Add instructions and example .env file for running tests locally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+SOLR_INSTANCE_DIR=tmp/sdr-core-test
+SOLR_INSTANCE_NAME=sdr-core-test
+SOLR_URL=http://127.0.0.1:8983/solr/sdr-core-test
+SOLR_PORT=8983
+SOLR_VERSION=9.2.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 `sdr-cli transform`  transforms a collection of GeoBlacklight 1.0 documents to OGM Aardvark
 
+## Development
+
+### Running Tests
+
+After checking out the project, copy `.env.example` to `.env`. These variables will inform the `solr_wrapper` gem how to start up a Solr instance when running the test suite.
+
+Then run the test suite with the following command:
+
+```bash
+$ bundle exec rake
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/NYULibraries/sdr-cli.


### PR DESCRIPTION
## Problem

Running the test suite without a `.env` file results in tests failing because a test instance of Solr is not spun up.

## Solution

Add an example `.env.example` file and provide instructions in the README

## Type

Chore