### PR TITLE
Auditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,13 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 ## Usage
 
-`sdr-cli clone`         clones all OGM repositories or pass --repo to clone a specific repository
-
-`sdr-cli help [COMMAND]`  Describe available commands or one specific command
-
-`sdr-cli index` index a directory of geospatial documents to Solr
-
-`sdr-cli pull` updates all OGM repositories or pass --repo to update a specific repository
-
-`sdr-cli transform`  transforms a collection of GeoBlacklight 1.0 documents to OGM Aardvark
+- `sdr-cli audit` compares a local NYU metadata repo with what's available in NYU GeoServer instances
+  - Example: `sdr-cli audit --directory tmp/opengeometadata/edu.nyu --destination tmp`
+- `sdr-cli clone` clones all OGM repositories or pass --repo to clone a specific repository
+- `sdr-cli help [COMMAND]` describe available commands or one specific command
+- `sdr-cli index` index a directory of geospatial documents to Solr
+- `sdr-cli pull` updates all OGM repositories or pass --repo to update a specific repository
+- `sdr-cli transform`  transforms a collection of GeoBlacklight 1.0 documents to OGM Aardvark
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -10,10 +10,19 @@ require 'standard/rake'
 task default: %i[spec standard]
 
 namespace :dev do
-  desc 'Test Auditor in development'
-  task :auditor do
-    require_relative 'lib/sdr_cli'
+  namespace :auditor do
+    desc 'Test Auditor in development'
+    task :light do
+      require_relative 'lib/sdr_cli'
 
-    SdrCli::Cli.start(%w[audit --directory ../edu.nyu --destination .])
+      SdrCli::Cli.start(%w[audit --directory ../edu.nyu --destination .])
+    end
+
+    desc 'Test Auditor in development'
+    task :full do
+      require_relative 'lib/sdr_cli'
+
+      SdrCli::Cli.start(%w[audit --directory ../edu.nyu --destination . --check-downloads])
+    end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,26 +1,26 @@
 # frozen_string_literal: true
 
-require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-require 'standard/rake'
+require "standard/rake"
 
 task default: %i[spec standard]
 
 namespace :dev do
   namespace :auditor do
-    desc 'Test Auditor in development'
+    desc "Test Auditor in development"
     task :light do
-      require_relative 'lib/sdr_cli'
+      require_relative "lib/sdr_cli"
 
       SdrCli::Cli.start(%w[audit --directory ../edu.nyu --destination .])
     end
 
-    desc 'Test Auditor in development'
+    desc "Test Auditor in development"
     task :full do
-      require_relative 'lib/sdr_cli'
+      require_relative "lib/sdr_cli"
 
       SdrCli::Cli.start(%w[audit --directory ../edu.nyu --destination . --check-downloads])
     end

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,19 @@
 # frozen_string_literal: true
 
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-require "standard/rake"
+require 'standard/rake'
 
 task default: %i[spec standard]
+
+namespace :dev do
+  desc 'Test Auditor in development'
+  task :auditor do
+    require_relative 'lib/sdr_cli'
+
+    SdrCli::Cli.start(%w[audit --directory ../edu.nyu --destination .])
+  end
+end

--- a/lib/sdr_cli.rb
+++ b/lib/sdr_cli.rb
@@ -3,6 +3,7 @@
 require_relative "sdr_cli/version"
 require_relative "sdr_cli/web_feature_service_client"
 require_relative "sdr_cli/web_map_service_client"
+require_relative "sdr_cli/aardvark_file"
 require_relative "sdr_cli/fetcher"
 require_relative "sdr_cli/transformer"
 require_relative "sdr_cli/indexer"

--- a/lib/sdr_cli.rb
+++ b/lib/sdr_cli.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative "sdr_cli/version"
+require_relative "sdr_cli/web_feature_service_client"
+require_relative "sdr_cli/web_map_service_client"
 require_relative "sdr_cli/fetcher"
 require_relative "sdr_cli/transformer"
 require_relative "sdr_cli/indexer"

--- a/lib/sdr_cli.rb
+++ b/lib/sdr_cli.rb
@@ -4,6 +4,7 @@ require_relative "sdr_cli/version"
 require_relative "sdr_cli/fetcher"
 require_relative "sdr_cli/transformer"
 require_relative "sdr_cli/indexer"
+require_relative "sdr_cli/auditor"
 require_relative "sdr_cli/cli"
 
 module SdrCli

--- a/lib/sdr_cli/aardvark_file.rb
+++ b/lib/sdr_cli/aardvark_file.rb
@@ -1,0 +1,36 @@
+module SdrCli
+  class AardvarkFile
+    def initialize(path)
+      @data = JSON.parse(File.read(path))
+      @references = JSON.parse(@data["dct_references_s"])
+    end
+
+    def wfs_url
+      @references["http://www.opengis.net/def/serviceType/ogc/wfs"]
+    end
+
+    def wms_url
+      @references["http://www.opengis.net/def/serviceType/ogc/wms"]
+    end
+
+    def download_url
+      @references["http://schema.org/downloadUrl"]
+    end
+
+    def access_rights
+      @data["dct_accessRights_s"]
+    end
+
+    def format
+      @data["dct_format_s"]
+    end
+
+    def title
+      @data["dct_title_s"]
+    end
+
+    def wxs_identifier
+      @data["gbl_wxsIdentifier_s"]
+    end
+  end
+end

--- a/lib/sdr_cli/auditor.rb
+++ b/lib/sdr_cli/auditor.rb
@@ -9,14 +9,15 @@ module SdrCli
   class Auditor
     attr_reader :directory, :destination
 
-    def initialize(directory:, destination:)
+    def initialize(directory:, destination:, check_downloads: false)
       @directory = directory
       @destination = destination
+      @check_downloads = check_downloads
     end
 
     def run
-      exit unless Dir.exist?(@directory)
-      exit unless Dir.exist?(@destination)
+      raise 'Cannot find metadata project directory' unless Dir.exist?(@directory)
+      raise 'Cannot find destination directory' unless Dir.exist?(@destination)
 
       csv_path = "#{@destination}/aardvark.csv"
 
@@ -31,12 +32,12 @@ module SdrCli
       public_wms_layers = wms_layer_names('https://maps-public.geo.nyu.edu/geoserver/sdr/wms').sort!
       restricted_wms_layers = wms_layer_names('https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms').sort!
 
-      headers = %i[category id access format download_url found_in_wfs found_in_wms title]
+      headers = %i[category id access format download_url download_status found_in_wfs found_in_wms title]
 
       json_files = Dir.glob("#{@directory}/metadata-aardvark/*/*.json")
 
       CSV.open(csv_path, 'w', headers:, write_headers: true) do |csv|
-        json_files.each do |path|
+        json_files.each_with_index do |path, index|
           parts = path.split('/')
           category = parts[-2]
           file = parts[-1]
@@ -60,12 +61,38 @@ module SdrCli
                             'N/A'
                           end
 
+          download_url = references['http://schema.org/downloadUrl']
+
+          if download_url
+            if @check_downloads
+              puts "Checking #{index + 1} of #{json_files.size} - #{download_url}..."
+              uri = URI(download_url)
+              http = Net::HTTP.new(uri.host, uri.port)
+              http.use_ssl = uri.scheme == 'https'
+              http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+              request = Net::HTTP::Head.new(uri)
+
+              begin
+                download_status = http.request(request).is_a?(Net::HTTPSuccess) ? 'Success' : 'Failed'
+              rescue StandardError => e
+                download_status = e.message
+              end
+
+              puts download_status
+            else
+              download_status = 'Skipped'
+            end
+          else
+            download_status = 'N/A'
+          end
+
           csv << [
             category,
             id,
             data['dct_accessRights_s'],
             data['dct_format_s'],
-            references['http://schema.org/downloadUrl'],
+            download_url,
+            download_status,
             wfs_existence,
             wms_existence,
             data['dct_title_s']

--- a/lib/sdr_cli/auditor.rb
+++ b/lib/sdr_cli/auditor.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'json'
-require 'csv'
-require 'nokogiri'
-require 'net/http'
+require "json"
+require "csv"
+require "nokogiri"
+require "net/http"
 
 module SdrCli
   class Auditor
@@ -16,86 +16,86 @@ module SdrCli
     end
 
     def run
-      raise 'Cannot find metadata project directory' unless Dir.exist?(@directory)
-      raise 'Cannot find destination directory' unless Dir.exist?(@destination)
+      raise "Cannot find metadata project directory" unless Dir.exist?(@directory)
+      raise "Cannot find destination directory" unless Dir.exist?(@destination)
 
       csv_path = "#{@destination}/aardvark.csv"
 
-      public_wfs_layers = wfs_layer_names('https://maps-public.geo.nyu.edu/geoserver/sdr/wfs').map do |name|
-        name.split(':')[1]
+      public_wfs_layers = wfs_layer_names("https://maps-public.geo.nyu.edu/geoserver/sdr/wfs").map do |name|
+        name.split(":")[1]
       end.sort!
 
-      restricted_wfs_layers = wfs_layer_names('https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs').map do |name|
-        name.split(':')[1]
+      restricted_wfs_layers = wfs_layer_names("https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs").map do |name|
+        name.split(":")[1]
       end.sort!
 
-      public_wms_layers = wms_layer_names('https://maps-public.geo.nyu.edu/geoserver/sdr/wms').sort!
-      restricted_wms_layers = wms_layer_names('https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms').sort!
+      public_wms_layers = wms_layer_names("https://maps-public.geo.nyu.edu/geoserver/sdr/wms").sort!
+      restricted_wms_layers = wms_layer_names("https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms").sort!
 
       headers = %i[category id access format download_url download_status found_in_wfs found_in_wms title]
 
       json_files = Dir.glob("#{@directory}/metadata-aardvark/*/*.json")
 
-      CSV.open(csv_path, 'w', headers:, write_headers: true) do |csv|
+      CSV.open(csv_path, "w", headers:, write_headers: true) do |csv|
         json_files.each_with_index do |path, index|
-          parts = path.split('/')
+          parts = path.split("/")
           category = parts[-2]
           file = parts[-1]
 
-          id = file.split('.').first.gsub('-', '_')
+          id = file.split(".").first.tr("-", "_")
           data = JSON.parse(File.read(path))
-          references = JSON.parse(data['dct_references_s'])
+          references = JSON.parse(data["dct_references_s"])
 
-          wfs_url = references['http://www.opengis.net/def/serviceType/ogc/wfs']
-          wms_url = references['http://www.opengis.net/def/serviceType/ogc/wms']
+          wfs_url = references["http://www.opengis.net/def/serviceType/ogc/wfs"]
+          wms_url = references["http://www.opengis.net/def/serviceType/ogc/wms"]
 
           wfs_existence = if wfs_url
-                            wfs_url.include?('public') ? public_wfs_layers.include?(id) : restricted_wfs_layers.include?(id)
-                          else
-                            'N/A'
-                          end
+            wfs_url.include?("public") ? public_wfs_layers.include?(id) : restricted_wfs_layers.include?(id)
+          else
+            "N/A"
+          end
 
           wms_existence = if wms_url
-                            wms_url.include?('public') ? public_wms_layers.include?(id) : restricted_wms_layers.include?(id)
-                          else
-                            'N/A'
-                          end
+            wms_url.include?("public") ? public_wms_layers.include?(id) : restricted_wms_layers.include?(id)
+          else
+            "N/A"
+          end
 
-          download_url = references['http://schema.org/downloadUrl']
+          download_url = references["http://schema.org/downloadUrl"]
 
           if download_url
             if @check_downloads
               puts "Checking #{index + 1} of #{json_files.size} - #{download_url}..."
               uri = URI(download_url)
               http = Net::HTTP.new(uri.host, uri.port)
-              http.use_ssl = uri.scheme == 'https'
+              http.use_ssl = uri.scheme == "https"
               http.verify_mode = OpenSSL::SSL::VERIFY_NONE
               request = Net::HTTP::Head.new(uri)
 
               begin
-                download_status = http.request(request).is_a?(Net::HTTPSuccess) ? 'Success' : 'Failed'
-              rescue StandardError => e
+                download_status = http.request(request).is_a?(Net::HTTPSuccess) ? "Success" : "Failed"
+              rescue => e
                 download_status = e.message
               end
 
               puts download_status
             else
-              download_status = 'Skipped'
+              download_status = "Skipped"
             end
           else
-            download_status = 'N/A'
+            download_status = "N/A"
           end
 
           csv << [
             category,
             id,
-            data['dct_accessRights_s'],
-            data['dct_format_s'],
+            data["dct_accessRights_s"],
+            data["dct_format_s"],
             download_url,
             download_status,
             wfs_existence,
             wms_existence,
-            data['dct_title_s']
+            data["dct_title_s"]
           ]
         end
       end
@@ -104,13 +104,13 @@ module SdrCli
     def wfs_layer_names(url)
       doc = Nokogiri::XML(Net::HTTP.get(URI("#{url}?service=wfs&version=1.3.0&request=GetCapabilities")))
       doc.remove_namespaces!
-      doc.xpath('//FeatureType/Name').map(&:text)
+      doc.xpath("//FeatureType/Name").map(&:text)
     end
 
     def wms_layer_names(url)
       doc = Nokogiri::XML(Net::HTTP.get(URI("#{url}?service=wms&version=1.3.0&request=GetCapabilities")))
       doc.remove_namespaces!
-      doc.xpath('//Layer/Name').map(&:text)
+      doc.xpath("//Layer/Name").map(&:text)
     end
   end
 end

--- a/lib/sdr_cli/auditor.rb
+++ b/lib/sdr_cli/auditor.rb
@@ -9,9 +9,7 @@ module SdrCli
   class Auditor
     attr_reader :directory, :destination
 
-    WFS_REFERENCE_KEY = "http://www.opengis.net/def/serviceType/ogc/wfs"
-    WMS_REFERENCE_KEY = "http://www.opengis.net/def/serviceType/ogc/wms"
-    DOWNLOAD_REFERENCE_KEY = "http://schema.org/downloadUrl"
+    HEADERS = %i[category file access format download_url download_status wxs_identifier wfs_status wms_status title]
 
     def initialize(directory:, destination:, check_downloads: false)
       @directory = directory
@@ -25,62 +23,55 @@ module SdrCli
 
       csv_path = "#{@destination}/aardvark.csv"
       json_files = Dir.glob("#{@directory}/metadata-aardvark/*/*.json")
-      headers = %i[category id access format download_url download_status found_in_wfs found_in_wms title]
 
-      public_wfs_layers = SdrCli::WebFeatureServiceClient.new("https://maps-public.geo.nyu.edu/geoserver/sdr/wfs").layer_names.map { |name| name.split(":")[1] }.sort!
-      restricted_wfs_layers = SdrCli::WebFeatureServiceClient.new("https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs").layer_names.map { |name| name.split(":")[1] }.sort!
+      public_wfs_layers = SdrCli::WebFeatureServiceClient.new("https://maps-public.geo.nyu.edu/geoserver/ows").layer_names
+      restricted_wfs_layers = SdrCli::WebFeatureServiceClient.new("https://maps-restricted.geo.nyu.edu/geoserver/ows").layer_names
 
-      public_wms_layers = SdrCli::WebMapServiceClient.new("https://maps-public.geo.nyu.edu/geoserver/sdr/wms").layer_names.sort!
-      restricted_wms_layers = SdrCli::WebMapServiceClient.new("https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms").layer_names.sort!
+      public_wms_layers = SdrCli::WebMapServiceClient.new("https://maps-public.geo.nyu.edu/geoserver/ows").layer_names
+      restricted_wms_layers = SdrCli::WebMapServiceClient.new("https://maps-restricted.geo.nyu.edu/geoserver/ows").layer_names
 
-      CSV.open(csv_path, "w", headers:, write_headers: true) do |csv|
+      CSV.open(csv_path, "w", headers: HEADERS, write_headers: true) do |csv|
         json_files.each_with_index do |path, index|
           *_, category, file = path.split("/")
 
-          id = file.split(".").first.tr("-", "_")
-          data = JSON.parse(File.read(path))
-          references = JSON.parse(data["dct_references_s"])
+          aardvark = SdrCli::AardvarkFile.new(path)
 
-          wfs_url = references[WFS_REFERENCE_KEY]
-          wms_url = references[WMS_REFERENCE_KEY]
-
-          wfs_existence = if wfs_url
-            available = wfs_url.include?("public") ? public_wfs_layers.include?(id) : restricted_wfs_layers.include?(id)
+          wfs_status = if aardvark.wfs_url
+            available = aardvark.wfs_url.include?("public") ? public_wfs_layers.include?(aardvark.wxs_identifier) : restricted_wfs_layers.include?(aardvark.wxs_identifier)
             available ? "Found" : "Missing"
           else
             "N/A"
           end
 
-          wms_existence = if wms_url
-            available = wms_url.include?("public") ? public_wms_layers.include?(id) : restricted_wms_layers.include?(id)
+          wms_status = if aardvark.wms_url
+            available = aardvark.wms_url.include?("public") ? public_wms_layers.include?(aardvark.wxs_identifier) : restricted_wms_layers.include?(aardvark.wxs_identifier)
             available ? "Found" : "Missing"
           else
             "N/A"
           end
 
-          download_url = references[DOWNLOAD_REFERENCE_KEY]
-
-          download_status = if download_url
+          download_status = if aardvark.download_url
             if @check_downloads
-              puts "Checking #{index + 1} of #{json_files.size} - #{download_url}..."
-              get_download_status(download_url)
+              puts "Checking #{index + 1} of #{json_files.size} - #{aardvark.download_url}..."
+              get_download_status(aardvark.download_url)
             else
-              "Skipped"
+              "Not Checked"
             end
           else
-            "N/A"
+            "No Download URL"
           end
 
           csv << [
             category,
-            id,
-            data["dct_accessRights_s"],
-            data["dct_format_s"],
-            download_url,
+            file,
+            aardvark.access_rights,
+            aardvark.format,
+            aardvark.download_url,
             download_status,
-            wfs_existence,
-            wms_existence,
-            data["dct_title_s"]
+            aardvark.wxs_identifier,
+            wfs_status,
+            wms_status,
+            aardvark.title
           ]
         end
       end

--- a/lib/sdr_cli/auditor.rb
+++ b/lib/sdr_cli/auditor.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'csv'
+require 'nokogiri'
+require 'net/http'
+
+module SdrCli
+  class Auditor
+    attr_reader :directory, :destination
+
+    def initialize(directory:, destination:)
+      @directory = directory
+      @destination = destination
+    end
+
+    def run
+      exit unless Dir.exist?(@directory)
+      exit unless Dir.exist?(@destination)
+
+      csv_path = "#{@destination}/aardvark.csv"
+
+      public_wfs_layers = wfs_layer_names('https://maps-public.geo.nyu.edu/geoserver/sdr/wfs').map do |name|
+        name.split(':')[1]
+      end.sort!
+
+      restricted_wfs_layers = wfs_layer_names('https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs').map do |name|
+        name.split(':')[1]
+      end.sort!
+
+      public_wms_layers = wms_layer_names('https://maps-public.geo.nyu.edu/geoserver/sdr/wms').sort!
+      restricted_wms_layers = wms_layer_names('https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms').sort!
+
+      headers = %i[category id access format download_url found_in_wfs found_in_wms title]
+
+      json_files = Dir.glob("#{@directory}/metadata-aardvark/*/*.json")
+
+      CSV.open(csv_path, 'w', headers:, write_headers: true) do |csv|
+        json_files.each do |path|
+          parts = path.split('/')
+          category = parts[-2]
+          file = parts[-1]
+
+          id = file.split('.').first.gsub('-', '_')
+          data = JSON.parse(File.read(path))
+          references = JSON.parse(data['dct_references_s'])
+
+          wfs_url = references['http://www.opengis.net/def/serviceType/ogc/wfs']
+          wms_url = references['http://www.opengis.net/def/serviceType/ogc/wms']
+
+          wfs_existence = if wfs_url
+                            wfs_url.include?('public') ? public_wfs_layers.include?(id) : restricted_wfs_layers.include?(id)
+                          else
+                            'N/A'
+                          end
+
+          wms_existence = if wms_url
+                            wms_url.include?('public') ? public_wms_layers.include?(id) : restricted_wms_layers.include?(id)
+                          else
+                            'N/A'
+                          end
+
+          csv << [
+            category,
+            id,
+            data['dct_accessRights_s'],
+            data['dct_format_s'],
+            references['http://schema.org/downloadUrl'],
+            wfs_existence,
+            wms_existence,
+            data['dct_title_s']
+          ]
+        end
+      end
+    end
+
+    def wfs_layer_names(url)
+      doc = Nokogiri::XML(Net::HTTP.get(URI("#{url}?service=wfs&version=1.3.0&request=GetCapabilities")))
+      doc.remove_namespaces!
+      doc.xpath('//FeatureType/Name').map(&:text)
+    end
+
+    def wms_layer_names(url)
+      doc = Nokogiri::XML(Net::HTTP.get(URI("#{url}?service=wms&version=1.3.0&request=GetCapabilities")))
+      doc.remove_namespaces!
+      doc.xpath('//Layer/Name').map(&:text)
+    end
+  end
+end

--- a/lib/sdr_cli/cli.rb
+++ b/lib/sdr_cli/cli.rb
@@ -68,8 +68,8 @@ module SdrCli
 
     desc "audit", "Compares the metadata repo with what's available in NYU GeoServer instances"
     long_desc <<-MSG
-      A command to compare the metadata repo with what's available in NYU GeoServer instances.
-      Pass the --directory option to specific the directory containing the NYU Metadata repository.
+      A command to compare a local metadata repo with what's available in NYU GeoServer instances.
+      Pass the --directory option to specify the directory containing an NYU Metadata repository.
       Pass the --destination option to specify the directory where the audit report CSV will be saved.
     MSG
 

--- a/lib/sdr_cli/cli.rb
+++ b/lib/sdr_cli/cli.rb
@@ -65,5 +65,24 @@ module SdrCli
 
       SdrCli::Transformer.new(directory: directory, destination: destination).run
     end
+
+    desc "audit", "Compares the metadata repo with what's available in NYU GeoServer instances"
+    long_desc <<-MSG
+      A command to compare the metadata repo with what's available in NYU GeoServer instances.
+      Pass the --directory option to specific the directory containing the NYU Metadata repository.
+      Pass the --destination option to specify the directory where the audit report CSV will be saved.
+    MSG
+
+    option :directory
+    option :destination
+    def audit
+      directory = options["directory"]
+      destination = options["destination"]
+
+      raise ArgumentError, "You must specify the metadata project directory" unless directory
+      raise ArgumentError, "You must specify a destination directory" unless destination
+
+      SdrCli::Auditor.new(directory: directory, destination: destination).run
+    end
   end
 end

--- a/lib/sdr_cli/cli.rb
+++ b/lib/sdr_cli/cli.rb
@@ -75,14 +75,16 @@ module SdrCli
 
     option :directory
     option :destination
+    option :check_downloads, type: :boolean
     def audit
       directory = options["directory"]
       destination = options["destination"]
+      check_downloads = options["check_downloads"]
 
       raise ArgumentError, "You must specify the metadata project directory" unless directory
       raise ArgumentError, "You must specify a destination directory" unless destination
 
-      SdrCli::Auditor.new(directory: directory, destination: destination).run
+      SdrCli::Auditor.new(directory: directory, destination: destination, check_downloads: check_downloads).run
     end
   end
 end

--- a/lib/sdr_cli/web_feature_service_client.rb
+++ b/lib/sdr_cli/web_feature_service_client.rb
@@ -1,0 +1,16 @@
+require "nokogiri"
+require "net/http"
+
+module SdrCli
+  class WebFeatureServiceClient
+    def initialize(base_url)
+      @base_url = base_url
+    end
+
+    def layer_names
+      doc = Nokogiri::XML(Net::HTTP.get(URI("#{@base_url}?service=wfs&version=1.3.0&request=GetCapabilities")))
+      doc.remove_namespaces!
+      doc.xpath("//FeatureType/Name").map(&:text)
+    end
+  end
+end

--- a/lib/sdr_cli/web_feature_service_client.rb
+++ b/lib/sdr_cli/web_feature_service_client.rb
@@ -8,7 +8,7 @@ module SdrCli
     end
 
     def layer_names
-      doc = Nokogiri::XML(Net::HTTP.get(URI("#{@base_url}?service=wfs&version=1.3.0&request=GetCapabilities")))
+      doc = Nokogiri::XML(Net::HTTP.get(URI("#{@base_url}?service=wfs&version=1.1.0&request=GetCapabilities")))
       doc.remove_namespaces!
       doc.xpath("//FeatureType/Name").map(&:text)
     end

--- a/lib/sdr_cli/web_map_service_client.rb
+++ b/lib/sdr_cli/web_map_service_client.rb
@@ -1,0 +1,16 @@
+require "nokogiri"
+require "net/http"
+
+module SdrCli
+  class WebMapServiceClient
+    def initialize(base_url)
+      @base_url = base_url
+    end
+
+    def layer_names
+      doc = Nokogiri::XML(Net::HTTP.get(URI("#{@base_url}?service=wms&version=1.3.0&request=GetCapabilities")))
+      doc.remove_namespaces!
+      doc.xpath("//Layer/Name").map(&:text)
+    end
+  end
+end

--- a/spec/sdr_cli/web_feature_service_client_spec.rb
+++ b/spec/sdr_cli/web_feature_service_client_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SdrCli::WebFeatureServiceClient do
+  describe "#layer_names" do
+    before do
+      allow(Net::HTTP).to receive(:get) {
+                            <<~XML
+                              <?xml version="1.0" encoding="UTF-8"?>
+                              <WFS_Capabilities>
+                                <FeatureTypeList>
+                                  <FeatureType>
+                                    <Name>foo</Name>
+                                  </FeatureType>
+                                  <FeatureType>
+                                    <Name>bar</Name>
+                                  </FeatureType>
+                                  <FeatureType>
+                                    <Name>baz</Name>
+                                  </FeatureType>
+                                </FeatureTypeList>
+                              </WFS_Capabilities>
+                            XML
+                          }
+    end
+
+    it "returns a list of layer names available from the service" do
+      wfs_client = SdrCli::WebFeatureServiceClient.new("https://maps-public.geo.nyu.edu/geoserver/sdr/wfs")
+
+      expect(wfs_client.layer_names).to include("foo", "bar", "baz")
+    end
+  end
+end

--- a/spec/sdr_cli/web_map_service_client_spec.rb
+++ b/spec/sdr_cli/web_map_service_client_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SdrCli::WebMapServiceClient do
+  describe "#layer_names" do
+    before do
+      allow(Net::HTTP).to receive(:get) {
+                            <<~XML
+                              <?xml version="1.0" encoding="UTF-8"?>
+                              <WMS_Capabilities>
+                                <Capability>
+                                  <Layer>
+                                    <Layer>
+                                      <Name>foo</Name>
+                                    </Layer>
+                                    <Layer>
+                                      <Name>bar</Name>
+                                    </Layer>
+                                    <Layer>
+                                      <Name>baz</Name>
+                                    </Layer>
+                                  </Layer>
+                                </Capability>
+                              </WMS_Capabilities>                              
+                            XML
+                          }
+    end
+
+    it "returns a list of layer names available from the service" do
+      wms_client = SdrCli::WebMapServiceClient.new("https://maps-public.geo.nyu.edu/geoserver/sdr/wms")
+
+      expect(wms_client.layer_names).to include("foo", "bar", "baz")
+    end
+  end
+end


### PR DESCRIPTION
## Problem

While working on various SDR issues I discovered that some records don't have the downloads, WMS or WFS layers their Aardvark files claim to have.

## Solution

Add a SDR CLI tasks to audit what's in the edu.nyu Aardvark files vs. what's on archive.nyu.edu and in the public and restricted WMS/WFS services.

## Type

Feature