### PR TITLE
Update CVE gems preventing SDR CVE update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     sdr_cli (0.2.1)
       dotenv (~> 2.7)
-      faraday (~> 2.10.1)
+      faraday (~> 2.14.1)
       thor (~> 1.4.0)
 
 GEM
@@ -26,6 +26,9 @@ GEM
     base64 (0.1.1)
     bigdecimal (3.1.8)
     builder (3.3.0)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
@@ -37,10 +40,12 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
     drb (2.2.1)
-    faraday (2.10.1)
-      faraday-net_http (>= 2.0, < 3.2)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
       logger
-    faraday-net_http (3.0.2)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     faraday-net_http_persistent (2.1.0)
       faraday (~> 2.5)
       net-http-persistent (~> 4.0)
@@ -84,15 +89,17 @@ GEM
     llhttp-ffi (0.4.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    logger (1.6.0)
+    logger (1.7.0)
     method_source (1.0.0)
     minitar (0.9)
     minitest (5.25.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
-    nokogiri (1.16.7-arm64-darwin)
+    nokogiri (1.19.0-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.7-x86_64-linux)
+    nokogiri (1.19.0-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.3)
@@ -103,13 +110,13 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (5.0.3)
-    racc (1.7.1)
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (13.0.6)
     rchardet (1.8.0)
     regexp_parser (2.8.1)
     retriable (3.1.2)
-    rexml (3.2.6)
+    rexml (3.4.4)
     rsolr (2.6.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
@@ -172,6 +179,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
+    uri (1.1.1)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -181,9 +189,11 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES
+  bundler-audit
   geo_combine (~> 0.9.2)
   pry (~> 0.14.2)
   rake (~> 13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sdr_cli (0.2.1)
+    sdr_cli (0.2.2)
       dotenv (~> 2.7)
       faraday (~> 2.14.1)
       thor (~> 1.4.0)

--- a/lib/sdr_cli/version.rb
+++ b/lib/sdr_cli/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SdrCli
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/sdr_cli.gemspec
+++ b/sdr_cli.gemspec
@@ -29,11 +29,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "dotenv", "~> 2.7"
-  spec.add_dependency "faraday", "~> 2.10.1"
+  spec.add_dependency "faraday", "~> 2.14.1"
   spec.add_dependency "thor", "~> 1.4.0"
   # spec.add_dependency "geo_combine", "~> 0.8.0"
   spec.add_development_dependency "solr_wrapper", "~> 4.0.2"
   spec.add_development_dependency "pry", "~> 0.14.2"
+  spec.add_development_dependency "bundler-audit"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
There is a Faraday CVE affecting SDR but sdr-cli is preventing that gem from being updated.

This PR updates the Faraday version but also adds bundler-audit to check for future CVEs. It also updates nokogiri and rexml which also had a number of CVEs.